### PR TITLE
XDP: copyediting and grammar fixes

### DIFF
--- a/kernel/Documentation/networking/XDP/design/design.rst
+++ b/kernel/Documentation/networking/XDP/design/design.rst
@@ -9,21 +9,22 @@ XDP is designed for programmability.
 
 Users want programmability as close as possible to the device
 hardware, to reap the performance gains, but they also want
-portability. The purpose of XDP is making such programs portable
-across multiple devices and vendors. (It is even imagined that XDP
-programs, should be able to run in userspace, either for simulation
-purposes or combined with other raw packet data-plane frameworks like
-netmap or DPDK).
+portability.  The purpose of XDP is making such programs portable
+across multiple devices and vendors.
 
-It is expected that, some HW vendors, take steps towards offloading
-XDP programs into their hardware.  It is fine they compete on this to
-sell more hardware. It is no different from producing the fastest
-chip. XDP encourage innovation, also for new HW features. But when
-extending XDP programs with a new hardware features (e.g. which only a
-single vendor supports), then this must be expressed towards the XDP
-API as a capability or features (see section `Capabilities
-negotiation`_).  This functions as a common capabilities API that
-vendors can choose implement (based on customer demand).
+(It is even imagined that XDP programs should be able to run in
+user space, either for simulation purposes or combined with other raw
+packet data-plane frameworks like netmap or DPDK).
+
+It is expected that some HW vendors will take steps towards offloading
+XDP programs into their hardware.  It is fine if they compete on this
+to sell more hardware.  It is no different from producing the fastest
+chip.  XDP also encourages innovation for new HW features, but when
+extending XDP programs with a new hardware feature (e.g. which only a
+single vendor supports), this must be expressed within the XDP API as
+a capability or feature (see section `Capabilities negotiation`_).
+This functions as a common capabilities API from which vendors can
+choose what to implement (based on customer demand).
 
 .. _ref_prog_negotiation:
 
@@ -32,40 +33,39 @@ Capabilities negotiation
 
 .. Warning:: This interface is missing in the implementation
 
-XDP have hooks and feature dependencies in the device drivers.
-Planning for extentability, not all device driver may support all the
-future features of XDP, and new feature adaptation in device driver
-will occur at different developement rates.
+XDP has hooks and feature dependencies in the device drivers.
+Planning for extendability, not all device drivers will necessarily
+support all of the future features of XDP, and new feature adoption
+in device drivers will occur at different development rates.
 
- Thus, there is a need for the device driver to express what XDP
- capabilities or features it provides.
+Thus, there is a need for the device driver to express what XDP
+capabilities or features it provides.
 
 When attaching/loading an XDP program into the kernel, a feature or
-capabilities negotiation should be conducted.  This implies an XDP
-program need to express what features it want to use.
+capabilities negotiation should be conducted.  This implies that an
+XDP program needs to express what features it wants to use.
 
-Loading an XDP program requesting features that the given device
-drivers does not support, should simply result in rejecting loading
-the program.
+If an XDP program being loaded requests features that the given device
+driver does not support, the program load should simply be rejected.
 
-.. note:: I'm undecided on whether to have an query interface?
-   Because users can just use the regular load-interface to probe for
-   supported options.  The down-side of probing is the issues SElinux
-   runs into, of false-alarms, when glibc tries to probe after
+.. note:: I'm undecided on whether to have an query interface, because
+   users could just use the regular load-interface to probe for
+   supported options.  The downside of probing is the issues SElinux
+   runs into, of false alarms, when glibc tries to probe for
    capabilities.
 
 
 Implementation issue
 --------------------
 
-The current implementation is missing this interface.  Worse the two
-actions :ref:`XDP_DROP` and :ref:`XDP_TX` should have been express as
-two different capabilities, because XDP_TX requires more changes to
+The current implementation is missing this interface.  Worse, the two
+actions :ref:`XDP_DROP` and :ref:`XDP_TX` should have been expressed
+as two different capabilities, because XDP_TX requires more changes to
 the device driver than a simple drop like XDP_DROP.
 
-One can (easily) imagine that an older driver only want to implement
-the XDP_DROP facility.  The reason is that XDP_TX would requires
-changing too much driver code, which is a concern for an old stable
+One can (easily) imagine that an older driver only wants to implement
+the XDP_DROP facility.  The reason is that XDP_TX would require
+changing too much driver code, which is a concern for an old, stable
 and time-proven driver.
 
 Data plane split

--- a/kernel/Documentation/networking/XDP/design/requirements.rst
+++ b/kernel/Documentation/networking/XDP/design/requirements.rst
@@ -5,64 +5,63 @@ Requirements
 Driver RX hook
 ==============
 
-Access to packet-data payload before allocating any meta-data
-structures, like SKBs.  It is key to performance, allowing processing
-RX "packet-pages" directly out of drivers RX ring queue.
+Gives us access to packet-data payload before allocating any meta-data
+structures, like SKBs.  This is key to performance, as it allows
+processing RX "packet-pages" directly out of the driver's RX ring
+queue.
 
 
 Early drop
 ==========
 
 Early drop is key for the DoS (Denial of Service) mitigation use-cases.
-It builds upon a principal of spending/investing as few CPU cycles as
+It builds upon a principle of spending/investing as few CPU cycles as
 possible on a packet that will get dropped anyhow.
 
-Doing this "inline" before delivery to the normal network stack, have
-the advantage that packets that does need delivery to the normal
-network stack, can still get all the features and benefits as before.
-(No need to deploy a bypass facility, just to reinject "good" packets
-into the stack again).
+Doing this "inline", before delivery to the normal network stack, has
+the advantage that a packet that *does* need delivery to the normal
+network stack can still get all the features and benefits as before;
+there is thus no need to deploy a bypass facility merely to re-inject
+"good" packets into the stack again.
 
 
-Write access to packet-data
+Write access to packet data
 ===========================
 
-Need the ability to modify packet-data.  This is unfortunately often
-difficult to obtain, as it requires fundamental changes to the drivers
-memory model.
+XDP needs the ability to modify packet data.  This is unfortunately
+often difficult to obtain, as it requires fundamental changes to the
+driver's memory model.
 
-Unfortunately most driver don't have "writable" packet-data as
-default.  The packet-data in drivers is often not writable, because
-the drivers likely have choosen to work-arounds performance
-bottlenecks in both the page-allocator and DMA APIs, which side-effect
-is read-only packet-pages.
+Unfortunately most drivers don't have "writable" packet data as
+default.  This is due to a workaround for performance bottlenecks in
+both the page-allocator and DMA APIs, which has the side-effect of
+necessitating read-only packet pages.
 
-Instead most drivers, allocate both a SKB and a writable memory
-buffer, which the packet headers are copied into (and for placing
-``skb_shared_info``). Afterwards the SKB (and ``skb_shared_info``) is
-adjusted to point into the remaining payload (pointing past the
-headers just copied).
+Instead, most drivers (currently) allocate both a SKB and a writable
+memory buffer, in which to copy ("linearise") the packet headers, and
+also store ``skb_shared_info``.  Then the remaining payload (pointing
+past the headers just copied) is attached as (read-only) paged data.
 
 
 Header push and pop
 ===================
 
 The ability to push (add) or pop (remove) packet headers indirectly
-depend on write acces to packet-data. (One could argue that a pure
-pop, could be implemented by only adjusting the payload offset, thus
-no write-access).
+depends on write access to packet-data.  (One could argue that a pure
+pop could be implemented by only adjusting the payload offset, thus
+not needing write access).
 
 This requirement goes hand-in-hand with tunnel encapsulation or
-decapsulation.  It is also relevant for e.g adding a VLAN head as
-needed by the :doc:`../use-cases/xdp_use_case_ddos_scrubber` in-order
-to workaround the :ref:`XDP_TX` single NIC limitation.
+decapsulation.  It is also relevant for e.g adding a VLAN header, as
+needed by the :doc:`../use-cases/xdp_use_case_ddos_scrubber` in order
+to work around the :ref:`XDP_TX` single NIC limitation.
 
 This requirement implies the ability to adjust the packet-data start
 offset/pointer and packet length.  This requires additional data to be
-returned
+returned.
 
-This also have implication for how much headroom drivers should
-reserve.
+This also has implications for how much headroom drivers should
+reserve in the SKB.
 
 
 Page per packet
@@ -73,9 +72,9 @@ Page per packet
 Packet forwarding
 =================
 
-Implementing a router/forwarding data plane is DPDK prime example for
-demonstrating superior performance.  For the shear ability to compare
-against DPDK, XDP also need a forwarding capability.
+Implementing a router/forwarding data plane is DPDK's prime example
+for demonstrating superior performance.  For the sheer ability to
+compare against DPDK, XDP also needs a forwarding capability.
 
 
 RX bulking

--- a/kernel/Documentation/networking/XDP/disclaimer.rst
+++ b/kernel/Documentation/networking/XDP/disclaimer.rst
@@ -10,18 +10,18 @@ Important to understand
 It is important to understand that the XDP speed gains comes at a cost
 of loss of generalization and fairness.
 
-XDP does not provide fairness. There is not buffering (qdisc) layer
-that absorbs traffic bursts when the TX device is too slow, packets
-will simply be dropped.  Don't use XDP in situations where the RX
-device is faster than the TX device, as there is not back-pressure to
-save packet from being dropped.  There is no qdisc layer or BQL (Byte
+XDP does not provide fairness. There is no buffering (qdisc) layer to
+absorb traffic bursts when the TX device is too slow, packets will
+simply be dropped.  Don't use XDP in situations where the RX device
+is faster than the TX device, as there is no back-pressure to save
+the packet from being dropped.  There is no qdisc layer or BQL (Byte
 Queue Limit) to save your from introducing massive bufferbloat.
 
 Using XDP is about specialization. Crafting a solution towards a very
 specialized purpose, that will require selecting and dimensioning the
-appropriate hardware. Using XDP it requires understanding the dangers
-and pitfalls, that comes from bypassing large parts of the kernel
-network stack code base, which is there for good reasons.
+appropriate hardware. Using XDP requires understanding the dangers and
+pitfalls, that come from bypassing large parts of the kernel network
+stack code base, which is there for good reasons.
 
 That said, XDP can be the right solution for some use-cases, and can
 yield huge (orders of magnitude) performance improvements, by allowing

--- a/kernel/Documentation/networking/XDP/implementation/drivers.rst
+++ b/kernel/Documentation/networking/XDP/implementation/drivers.rst
@@ -2,9 +2,9 @@
 Drivers
 =======
 
-XDP have a dependency on drivers implementing the RX hook and setup
-API.  Adding driver support is fairly easy, unless it requires
-changing the drivers memory model (which is often the case).
+XDP depends on drivers implementing the RX hook and set-up API.
+Adding driver support is fairly easy, unless it requires changing the
+driver's memory model (which is often the case).
 
 
 Mellanox: mlx4

--- a/kernel/Documentation/networking/XDP/implementation/missing_features.rst
+++ b/kernel/Documentation/networking/XDP/implementation/missing_features.rst
@@ -22,7 +22,7 @@ See: :ref:`ref_prog_negotiation`
 Missing: XDP program per RX queue
 =================================
 
-Changes to the userspace API is needed to add this feature.
+Changes to the user space API are needed to add this feature.
 
 Missing: Cache prefetching
 ==========================

--- a/kernel/Documentation/networking/XDP/implementation/userspace_api.rst
+++ b/kernel/Documentation/networking/XDP/implementation/userspace_api.rst
@@ -4,13 +4,13 @@ Userspace API
 
 .. Warning::
 
-   The userspace API specification should have to be defined properly
-   before code was accepted upstream.  Concerns have been raise about
+   The userspace API specification should have been defined properly
+   before code was accepted upstream.  Concerns have been raised about
    the current API upstream.  Users should expect this first API
-   attempt will need adjustments. This cannot be considered a stable
+   attempt will need adjustments; this cannot be considered a stable
    API yet.
 
-   Most importantly is the missing capabilities negotiation,
+   Most importantly, capabilities negotiation is missing;
    see :ref:`ref_prog_negotiation`.
 
 
@@ -32,32 +32,32 @@ Struct xdp_prog
 ---------------
 
 Currently (4.8-rc6) the XDP program is simply a bpf_prog pointer.
-While it is good for simplicity, it is limiting extendability for
+While this is good for simplicity, it limits extendability for
 upcoming features.
 
-Introducing a new ``struct xdp_prog``, that can carry information
-related to the XDP program.  Notice this approach does not affect
-performance (tested and benchmarked), because the extra dereference
-for the eBPF program only happens once per 64 packets in the poll
-function.
+Maybe we should introduce a new ``struct xdp_prog`` that can carry
+information related to the XDP program.  Notice this approach does
+not affect performance (tested and benchmarked), because the extra
+dereference for the eBPF program only happens once per 64 packets in
+the poll function.
 
-The features that need this is:
+The features that need this are:
 
 * Multi-port TX:
   Need to know own port index and port lookup table.
 
 * XDP program per RX queue:
   Need setup info about program type, global or specific, due to
-  replace semantics.
+  program-replacement semantics.
 
 * Capabilities negotiation:
-  Need to store information about features program want to use,
-  in-order to validate this.
+  Need to store information about features program wants to use,
+  in order to validate this.
 
 .. TODO:: How kernel devel works: This new ``struct xdp_prog``
-   features cannot go into the kernel before one of the three users of
-   the struct is also implemented. (Note, Jesper have implemented this
-   struct change and have even benchmarked that it does not hurt
+   feature cannot go into the kernel before one of the three users of
+   the struct is also implemented.  (Note, Jesper has implemented this
+   struct change and has even benchmarked that it does not hurt
    performance).
 
 
@@ -67,14 +67,14 @@ Troubleshooting and Monitoring
 ==============================
 
 Users need the ability to both monitor and troubleshoot an XDP
-program. Partigular in case of error events like :ref:`XDP_ABORTED`,
-and in case a XDP programs starts to return invalid and unsupported
-action code (caught by the :ref:`action fall-through`).
+program; particularly so in case of error events like :ref:`XDP_ABORTED`,
+and in case an XDP program starts to return invalid and unsupported
+action codes (caught by the :ref:`action fall-through`).
 
 .. Warning::
 
    The current (4.8-rc6) implementation is not optimal in this area.
-   In case of the :ref:`action fall-through` packets is dropped and a
+   In the :ref:`action fall-through` case, the packet is dropped and a
    warning is generated **only once** about the invalid XDP program
    action code, by calling: bpf_warn_invalid_xdp_action(action_code);
 
@@ -84,19 +84,19 @@ Two options are on the table currently:
 
 * Counters.
 
-  Simply add counters to track these events.  This allow admins and
-  monitor tools to catch and count these events.  This does requires
+  Simply add counters to track these events.  This allows admins and
+  monitoring tools to catch and count these events.  This does require
   standardizing these counters to help monitor tools.
 
 * Tracepoints.
 
-  Another option is adding tracepoint to these situations.  It is much
-  more flexible than counters.  The downside is that these error
+  Another option is adding tracepoints to these situations.  These are
+  much more flexible than counters.  The downside is that these error
   events might never be caught, if the tracepoint isn't active.
 
-An important design consideration is the monitor facility must not be
-too expensive to execute, even-though events like :ref:`XDP_ABORTED`
-and :ref:`action fall-through` should be very rare events.  This is
+An important design consideration is that the monitor facility must
+not be too expensive to execute, even though events like :ref:`XDP_ABORTED`
+and :ref:`action fall-through` should normally be very rare.  This is
 because an external attacker (given the DDoS uses-cases) might find a
 way to trigger these events, which would then serve as an attack
 vector against XDP.

--- a/kernel/Documentation/networking/XDP/implementation/xdp_actions.rst
+++ b/kernel/Documentation/networking/XDP/implementation/xdp_actions.rst
@@ -8,16 +8,16 @@
 XDP actions
 ===========
 
-.. TODO:: Missing desc for XDP_TX.
+.. TODO:: Missing description for XDP_TX.
 
 .. _XDP_PASS:
 
 XDP_PASS
 ========
 
-XDP_PASS means the XDP program choose to pass the packet to the normal
-network stack for processing.  Do notice that the XDP program is
-allowed to have modified the packet-data.
+XDP_PASS means the XDP program chose to pass the packet to the normal
+network stack for processing.  Note that the XDP program is allowed to
+have modified the packet-data.
 
 
 .. _XDP_DROP:
@@ -49,7 +49,7 @@ ever use as a return code.  This return code is something an ``eBPF``
 program returns in case of an eBPF program error, e.g. division by
 zero.  For this reason XDP_ABORTED will always be the value zero.
 
- This XDP_ABORTED action results in the packet getting dropped.
+This XDP_ABORTED action results in the packet getting dropped.
 
 For how to troubleshoot this kind of unlikely error event, see the
 section :ref:`Troubleshooting and Monitoring`.
@@ -63,7 +63,7 @@ There must also be a fall-through ``default:`` case, which is hit if
 the program returns an unknown action code (e.g. future action this
 driver does not support).
 
- These unknown return codes will result in packet drop.
+These unknown return codes will result in packet drop.
 
 See the section :ref:`Troubleshooting and Monitoring` for how to catch
 these kind of situations.
@@ -95,6 +95,6 @@ statement as below.
 		}
 	}
 
-.. Warning:: It is still undecided if the ``action`` code need to be
-             partitioned into opcodes and some of the upper-bits use
-             as values for the given opcode.
+.. Warning:: It is still undecided whether the ``action`` code needs
+             to be partitioned into opcodes, with some of the upper
+             bits used as values for the given opcode.

--- a/kernel/Documentation/networking/XDP/introduction.rst
+++ b/kernel/Documentation/networking/XDP/introduction.rst
@@ -10,7 +10,7 @@ network data path in the Linux kernel. XDP provides bare metal packet
 processing at the lowest point in the software stack.  Much of the
 huge speed gain comes from processing RX packet-pages directly out of
 drivers RX ring queue, before any allocations of meta-data structures
-like SKB's occurs.
+like SKBs occurs.
 
 The IO Visor Project have an `introduction to XDP`_.
 

--- a/kernel/Documentation/networking/XDP/presentations.rst
+++ b/kernel/Documentation/networking/XDP/presentations.rst
@@ -8,7 +8,7 @@ List of XDP focused presentations:
  * `September 2016`_ - Red Hat Inc. (Jesper Brouer)
 
 Historically the `Network Performance BoF`_ at NetDev 1.1 (Feb 2016)
-were the first presentation to propose the idea of processing RX
+was the first presentation to propose the idea of processing RX
 packet-pages directly out of the driver RX ring queue.
 
 .. _Network Performance BoF:

--- a/kernel/Documentation/networking/XDP/use-cases/index.rst
+++ b/kernel/Documentation/networking/XDP/use-cases/index.rst
@@ -2,7 +2,7 @@
 Use-cases
 =========
 
-XDP use-cases, some are only proposals.
+XDP use-cases; some are only proposals.
 
 Contents:
 

--- a/kernel/Documentation/networking/XDP/use-cases/xdp_use_case_ddos.rst
+++ b/kernel/Documentation/networking/XDP/use-cases/xdp_use_case_ddos.rst
@@ -2,10 +2,10 @@
 Use-case: DDoS
 ==============
 
-DDoS protection was the primary use-case XDP was born-out-of.
+DDoS protection was the primary use-case XDP was born out of.
 CloudFlare_ presented their `DDoS use-case`_ at the `Network
-Performance BoF`_ at NetDev 1.1, which convinced many Kernel developer
-that this was something that needed to be solved.
+Performance BoF`_ at NetDev 1.1, which convinced many Kernel
+developers that this was something that needed to be solved.
 
 
 .. _Network Performance BoF:
@@ -21,17 +21,17 @@ End-host protection
 ===================
 
 When a server is under DoS (Denial-of-Service) attack, the attacker is
-trying to use as many resource on the server as possible, in-order to
+trying to use as many resource on the server as possible, in order to
 not leave processing time to service the legitimate users.
 
-Due to XDP running so early in the software stack, almost no
-processing cost is associated with dropping a packet. This makes it a
+Owing to XDP running so early in the software stack, there is almost
+no processing cost associated with dropping a packet. This makes it a
 viable option to load a XDP program directly on the server, as
 filtering out bad/attacker traffic (this early) frees up processing
 resources.
 
 As XDP is still part of the Linux network stack, packets that "pass"
-the XDP filter, still have all features for further filtering that the
-kernel normally provide.  It works in concert with the regular network
-stack.
+the XDP filter still have all features for further filtering that the
+kernel normally provides.  It works in concert with the regular
+network stack, rather than trying to by-pass it.
 

--- a/kernel/Documentation/networking/XDP/use-cases/xdp_use_case_ddos_scrubber.rst
+++ b/kernel/Documentation/networking/XDP/use-cases/xdp_use_case_ddos_scrubber.rst
@@ -4,7 +4,7 @@ Use-case: DDoS scrubber
 :Version: 0.2
 :Status: Proposal, need some new XDP features
 
-This document investigate if XDP can be used for implementing a
+This document investigates whether XDP can be used for implementing a
 machine that does traffic scrubbing at the edge of the network.
 
 DDoS volume attacks
@@ -15,9 +15,9 @@ traffic scrubbing or cleaning when getting attacked by DDoS volume
 attacks.  They have much larger pipes to the Internet than their
 internal backbone can actually handle.
 
-Usually a specific IP-address is attacked.  Then that happens the
-IP-address is placed into a MPLS-VRF alternative route-tables, that
-gets routed through/passed some scrubbing servers.
+Usually a specific IP address is attacked.  When that happens, the IP
+address is placed into MPLS-VRF alternative routing tables, so the
+traffic gets routed through some scrubbing servers.
 
 The purpose of the scrubbing servers is to reduce (or drop) enough
 traffic, such that the DoS volume attack is less than the capacity of
@@ -26,12 +26,13 @@ the internal backbone.
 Forward clean traffic
 =====================
 
-The clean/good traffic need to be forwarded towards backbone.
+The clean/good traffic needs to be forwarded towards the internal
+backbone.
 
-To get around the XDP limitation of only sending back-out the same
-NIC.  They want to add a VLAN header to the packet before calling
-XDP_TX, as this allows them to catch the traffic and re-steer it back
-into the main MPLS-VRF routing table.
+To get around the XDP limitation of only sending back out the same
+NIC, they want to add a VLAN header to the packet before calling
+XDP_TX, allowing them to catch the traffic and re-steer it back into
+the main MPLS-VRF routing table.
 
 
 Need: traffic sampling XDP_DROP
@@ -42,20 +43,21 @@ false positives.  This could be implemented by sampling the drop
 traffic, by returning XDP_PASS a percentage of the times, and then
 have a userspace tcpdump running.
 
-To communicate which eBPF rule that caused the drop, they were
-thinking of modifying the packet header adding a VLAN id.  That way
-the tcpdump could run on a net_device with a given VLAN.
+To indicate which eBPF rule caused the drop, they were thinking of
+modifying the packet header by adding a VLAN id.  That way the tcpdump
+could run on a net_device with a given VLAN.
 
 .. note::
 
-   **NEW-ACTION**: The sampling could be implemented more effecient,
-   if implementing a XDP_DUMP facility for AF_PACKET.
+   **NEW-ACTION**: The sampling could be implemented more efficiently,
+   if there were a XDP_DUMP action which sent the sampled packets to
+   an AF_PACKET socket.
 
 Need: traffic sampling XDP_TX
 =============================
 
 If the scrubber filter is not good enough, then too much bad traffic
-is allowed through.  This is usually the basecase, once the attack
+is allowed through.  This is usually the base case, once the attack
 starts.
 
 Thus, they have need for analysing the traffic that gets forwarded
@@ -63,35 +65,35 @@ with XDP_TX. (ISSUE) The is currently no way to sample or dump the
 XDP_TX traffic.
 
 A physical solution could be to do switch-port mirroring of the
-traffic, and then have another machine (of even the same machine)
-receive traffic for analyzing.  They were talking about just using the
-same machine (as there usually are two NIC ports). (Worry that this
-would cost double the PCIe bandwidth),
+traffic, and then have another machine (or even the same machine)
+receive traffic for analysis.  They were talking about just using the
+same machine (as there usually are two NIC ports), but the worry is
+that this would cost double the PCIe bandwidth.
 
 .. warning::
 
    **NEW-FEATURE:** A software solution could be a combination of
-   XDP_TX and XDP_DUMP.  Both doing XDP_TX and XDP_DUMP would only
+   XDP_TX and XDP_DUMP.  Doing both XDP_TX and XDP_DUMP would only
    cost an extra page refcnt.  They only need sampling.  The XDP_DUMP
-   should be implemented such that it have a limited queue size and
-   simply drops on queue full.
+   should be implemented such that it has a limited queue size, and
+   simply drops if the queue is full.
 
 
 Need: smaller eBPF programs
 ---------------------------
 
 They experience different DDoS attacks.  They don't want to have one
-big eBPF program that need to handle every kind of attack.  This
+big eBPF program that needs to handle every kind of attack.  This
 program would also get too slow once the size increase.
 
 DDoS attacks are usually very specific, and are often stopped by
 spotting a very specific pattern in the packet that is constant enough
-to identify the bad traffic. It is key that they can quicky constuct a
-XDP program matching this very specific pattern without risking
+to identify the bad traffic.  It is key that they can quicky construct
+an XDP program matching this very specific pattern, without risking
 affecting the stability of other XDP filters.
 
 They also have a need to handle several simultaneous attacks, usually
-happens against different destination IP-addresses.
+targeting different destination IP addresses.
 
 .. warning::
 
@@ -103,7 +105,7 @@ happens against different destination IP-addresses.
 Ethtool filters for mlx4
 ------------------------
 
-The HW filter capabilities is highly dependend on the HW, and limited
+The HW filter capabilities are highly dependent on the HW, and limited
 by what can be expressed by ethtool.
 
 From below documentation, it looks like mlx4 have the filters needed

--- a/kernel/Documentation/networking/XDP/use-cases/xdp_use_case_load_balancer.rst
+++ b/kernel/Documentation/networking/XDP/use-cases/xdp_use_case_load_balancer.rst
@@ -22,16 +22,16 @@ which is a pure-python replacement for ipvsadm_ (`ipvsadm git`_ tree).
 Traditional load balancer
 =========================
 
-Traditionally a service load balancer, like IPVS, have more NICs
-(Network Interface Cards) and forward traffic to the back-end servers
-(called "real server" for IPVS).
+Traditionally a service load balancer (like IPVS) has more NICs
+(Network Interface Cards), and forwards traffic to the back-end
+servers (called "real server" for IPVS).
 
 The current XDP implementation (**XDP_TX** in kernel 4.8) can only
-forward packets back-out the same NIC they arrived on.  This makes XDP
+forward packets back out the same NIC they arrived on.  This makes XDP
 unsuited for implementing a traditional multi-NIC load balancer.
 
-A traditionally load balancer easily becomes a single point of
-failure.  Thus, more than one load balancer are usually deployed in a
+A traditional load balancer easily becomes a single point of failure.
+Thus, multiple load balancers are usually deployed, in a
 `High Availability`_ (HA) cluster.  In order to make load balancer
 failover transparent to client applications, the load balancer(s) need
 to synchronize their state (E.g. via `IPVS sync protocol`_ sending UDP
@@ -46,8 +46,8 @@ multicast, preferable send on a separate network/NIC).
 Untraditional XDP load balancer
 ===============================
 
-Imagine implementing a load-balancer without any dedicated servers for
-load balancing, 100% scalable and no single point of failure.
+Imagine implementing a load balancer without any dedicated servers for
+load balancing, 100% scalable and with no single point of failure.
 
  Be the load balancer yourself!
 
@@ -57,8 +57,8 @@ no dedicated central server.
 
 It corresponds to running IPVS on the backend ("real servers"), which
 is possible, and some `IPVS examples`_ are available (e.g `Ultra
-Monkey`_). But it is generally not recommended (in high load
-situations) because it increases the load on the application server
+Monkey`_). But that is generally not recommended (in high load
+situations), because it increases the load on the application server
 itself, which leaves less CPU time for serving requests.
 
 .. _IPVS examples: http://kb.linuxvirtualserver.org/wiki/Examples
@@ -67,12 +67,12 @@ itself, which leaves less CPU time for serving requests.
 
  Why is this a good idea for XDP then?
 
-XDP have a speed advantage.  The XDP load balance forwarding decision
-happens **very** early, before the OS have spend/invested too many
+XDP has a speed advantage.  The XDP load balance forwarding decision
+happens **very** early, before the OS has spent/invested too many
 cycles on the packet.  This means the XDP load balancing functionality
 should not increase the load on the server significantly.  Thus, it
 should okay to run the service and LB on the same server.  One can
-even imagine, having a feedback loop into the LB-program decision
+even imagine having a feedback loop into the LB-program decision,
 based on whether the service is struggling to keep up.
 
 Who will balance the incoming traffic?
@@ -108,13 +108,13 @@ When using the same network segment for the load balancing traffic
 dimensioning the network capacity.
 
 One can create a cluster of servers, all connected to the same
-10Gbit/s switch and the switch have the same 10Gbit/s uplink capacity
+10Gbit/s switch, and the switch has the same 10Gbit/s uplink capacity
 limitation. The 10Gbit/s capacity is bidirectional, meaning both RX
 and TX have 10Gbit/s.  No (incoming) network overload situation can
 occur, because the uplink can only forward with 10G, and LB server can
 RX with 10G and TX with 10G to another "service-server", happening
 over the Ethernet switch fabric, thus RX capacity of the
-"service-server" is still 10G.  Sending traffic back to the uplink,
+"service-server" is still 10G.  Sending traffic back to the uplink
 happens via "direct-return" from the "service-server", still have 10G
 capacity left in the Ethernet switch fabric.  Thus, with a proper HW
 setup the XDP_TX limitation can be dealt with.
@@ -128,8 +128,9 @@ Need: RX HW hash
    **FEATURE**:
    provide NIC RX HW hash has as meta-data input to XDP program.
 
-As scheme to determine which **flows** a given server is responsible
-serving, can benefit from getting the NIC RX hardware hash as input.
+A scheme to determine which **flows** a given server is responsible
+for serving can benefit from getting the NIC RX hardware hash as
+input.
 
 The XDP load balancing decision can be made faster, if it does not
 have to read+parse the packet contents before making a route decision.


### PR DESCRIPTION
I've attempted to clean up the language (and in some places, fiddled with formatting) of the XDP docs.  However, there may be places where I've misunderstood the original and "clarified" it to mean something else; so please do check I've not perverted the intent of the text.