### PR TITLE
samples/bpf: fix link issue with older gcc

### DIFF
--- a/kernel/samples/bpf/Makefile
+++ b/kernel/samples/bpf/Makefile
@@ -149,7 +149,7 @@ $(KERN_OBJECTS): %.o: %.c
 	$(LLC) -march=bpf -filetype=obj -o $@ ${@:.o=.ll}
 
 $(TARGETS): %: %_user.c $(OBJECTS) Makefile
-	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJECTS) -o $@ $<
+	$(CC) $(CFLAGS) $(OBJECTS) $(LDFLAGS) -o $@ $<
 
 $(CMDLINE_TOOLS): %: %.c $(OBJECTS) Makefile $(COMMON_H)
-	$(CC) -g $(CFLAGS) $(LDFLAGS) $(OBJECTS) -o $@ $<
+	$(CC) -g $(CFLAGS) $(OBJECTS) $(LDFLAGS) -o $@ $<


### PR DESCRIPTION
gcc -O2 -Wall -I/lib/modules/4.10.0-rc8+/build//usr/include -I/lib/modules/4.10.0-rc8+/build//tools/lib -I/lib/modules/4.10.0-rc8+/build//tools/include -I/lib/modules/4.10.0-rc8+/build//tools/perf -I/lib/modules/4.10.0-rc8+/build//tools/testing/selftests/bpf/ -lelf -ldwarf bpf.o bpf_load.o -o xdp_ddos01_blacklist xdp_ddos01_blacklist_user.c
bpf_load.o: In function `get_sec.isra.1':
bpf_load.c:(.text+0x31): undefined reference to `elf_getscn'
bpf_load.c:(.text+0x49): undefined reference to `gelf_getshdr'
bpf_load.c:(.text+0x7b): undefined reference to `elf_strptr'
bpf_load.c:(.text+0x9a): undefined reference to `elf_getdata'
bpf_load.c:(.text+0xad): undefined reference to `elf_getdata'
bpf_load.o: In function `load_bpf_file':
bpf_load.c:(.text+0x8ad): undefined reference to `elf_version'
bpf_load.c:(.text+0x907): undefined reference to `elf_begin'
bpf_load.c:(.text+0x922): undefined reference to `gelf_getehdr'
bpf_load.c:(.text+0xd9e): undefined reference to `gelf_getrel'
bpf_load.c:(.text+0xdbf): undefined reference to `gelf_getsym'
collect2: error: ld returned 1 exit status
Makefile:152: recipe for target 'xdp_ddos01_blacklist' failed
make: *** [xdp_ddos01_blacklist] Error 1

Failure to link properly with gcc on Ubuntu 16.04.

$ gcc --version
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609

Signed-off-by: Andy Gospodarek <andy@greyhouse.net>