### PR TITLE
docs: add missing underscore to bpf samples link

### DIFF
--- a/kernel/Documentation/networking/XDP/end-user/coding.rst
+++ b/kernel/Documentation/networking/XDP/end-user/coding.rst
@@ -28,7 +28,7 @@ project under `prototype-kernel/kernel/samples/bpf`_.
 
 .. _prototype-kernel: https://github.com/netoptimizer/prototype-kernel
 
-.. prototype-kernel/kernel/samples/bpf:
+.. _prototype-kernel/kernel/samples/bpf:
    https://github.com/netoptimizer/prototype-kernel/tree/master/kernel/samples/bpf
 
 Special XDP eBPF cases


### PR DESCRIPTION
This should render correctly with the PDF.