### PR TITLE
samples/bpf: cleanup JSON output and count TCP and UDP drops separately

### DIFF
--- a/kernel/samples/bpf/xdp_ddos01_blacklist_cmdline.c
+++ b/kernel/samples/bpf/xdp_ddos01_blacklist_cmdline.c
@@ -227,6 +227,7 @@ static void blacklist_list_all(int fd)
 
 	printf("{\n");
 	while (bpf_map_get_next_key(fd, &key, &next_key) == 0) {
+		printf("%s", key ? "," : " ");
 		key = next_key;
 		value = get_key32_value64_percpu(fd, key);
 		blacklist_print_ip(key, value);

--- a/kernel/samples/bpf/xdp_ddos01_blacklist_common.h
+++ b/kernel/samples/bpf/xdp_ddos01_blacklist_common.h
@@ -28,7 +28,10 @@ static const char *file_blacklist = "/sys/fs/bpf/ddos_blacklist";
 static const char *file_verdict   = "/sys/fs/bpf/ddos_blacklist_stat_verdict";
 
 static const char *file_port_blacklist = "/sys/fs/bpf/ddos_port_blacklist";
-static const char *file_port_blacklist_count = "/sys/fs/bpf/ddos_port_blacklist_count";
+static const char *file_port_blacklist_count[] = {
+	"/sys/fs/bpf/ddos_port_blacklist_count_tcp",
+	"/sys/fs/bpf/ddos_port_blacklist_count_udp"
+};
 
 
 // TODO: create subdir per ifname, to allow more XDP progs
@@ -56,8 +59,9 @@ uint64_t gettime(void)
 #define ACTION_DEL	(1 << 1)
 
 enum {
-        DDOS_FILTER_TCP = 0,
-        DDOS_FILTER_UDP,
+	DDOS_FILTER_TCP = 0,
+	DDOS_FILTER_UDP,
+	DDOS_FILTER_MAX
 };
 
 static int blacklist_modify(int fd, char *ip_string, unsigned int action)


### PR DESCRIPTION
JSON output back to being considered valid when checking with json lint checker.

{
 "10.10.10.10" : 0,
 "198.18.50.3" : 0,
 "80" : {
	"TCP" : 119,
	"UDP" : 5355522134
 },
 "800" : {
	"TCP" : 0
 }
}