### PR TITLE
docs: fix typo

### DIFF
--- a/kernel/Documentation/networking/XDP/design/requirements.rst
+++ b/kernel/Documentation/networking/XDP/design/requirements.rst
@@ -82,7 +82,7 @@ page.  This simplifies page handling and open up for future
 extensions.
 
 This requirement also (upfront) result in choosing not to support
-things like, jumpo-frames, LRO and generally packets split over
+things like, jumbo-frames, LRO and generally packets split over
 multiple pages.
 
 In the future, this strict memory model might be relaxed, but for now


### PR DESCRIPTION
o s/jumpo/jumbo

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>