### PR TITLE
docs: use Lin Grok for bpf_map_type link

### DIFF
--- a/kernel/Documentation/bpf/ebpf_maps_types.rst
+++ b/kernel/Documentation/bpf/ebpf_maps_types.rst
@@ -32,7 +32,7 @@ but remember to `lookup latest`_ available maps in the source code.
 .. section links
 
 .. _lookup latest:
-   http://lxr.free-electrons.com/ident?i=bpf_map_type
+   http://lingrok.org/search?project=linux-net-next&q=bpf_map_type
 
 Implementation details
 ======================


### PR DESCRIPTION
This should show what is in net-next and is newer than lxr.

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>