### PR TITLE
samples/bpf: add missing include for bool

### DIFF
--- a/kernel/samples/bpf/bpf_tail_calls01_user.c
+++ b/kernel/samples/bpf/bpf_tail_calls01_user.c
@@ -8,6 +8,7 @@ static const char *__doc__= " Test of bpf_tail_call from XDP program\n\n"
 #include <signal.h>
 #include <net/if.h>
 #include <unistd.h>
+#include <stdbool.h>
 #include <linux/if_link.h>
 
 #include "libbpf.h"


### PR DESCRIPTION
Fixes the following error

	make -C samples/bpf/ kbuilddir=/lib/modules/4.11.3-202.fc25.x86_64/build/
	make[1]: Entering directory '/home/vagrant/src/tmp/prototype-kernel/kernel/samples/bpf'
	gcc -O2 -Wall -I./tools/lib -I./tools/include -I/lib/modules/4.11.3-202.fc25.x86_64/build//tools/incl
	ude -I/lib/modules/4.11.3-202.fc25.x86_64/build//usr/include tools/lib/bpf/bpf.o bpf_load.o -lelf -o
	bpf_tail_calls01 bpf_tail_calls01_user.c
	bpf_tail_calls01_user.c:21:8: error: unknown type name ‘bool’
	 static bool debug = false;
	        ^~~~
	bpf_tail_calls01_user.c:21:21: error: ‘false’ undeclared here (not in a function)
	 static bool debug = false;
	                     ^~~~~
	bpf_tail_calls01_user.c: In function ‘main’:
	bpf_tail_calls01_user.c:141:12: error: ‘true’ undeclared (first use in this function)
	    debug = true;
	            ^~~~
	bpf_tail_calls01_user.c:141:12: note: each undeclared identifier is reported only once for each funct
	ion it appears in
	Makefile:176: recipe for target 'bpf_tail_calls01' failed
	make[1]: *** [bpf_tail_calls01] Error 1
	make[1]: Leaving directory '/home/vagrant/src/tmp/prototype-kernel/kernel/samples/bpf'
	Makefile:34: recipe for target 'bpf' failed
	make: *** [bpf] Error 2

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>