### PR TITLE
samples/bpf: add missing include for uint64_t

### DIFF
--- a/kernel/samples/bpf/napi_monitor_user.c
+++ b/kernel/samples/bpf/napi_monitor_user.c
@@ -12,6 +12,7 @@ static const char *__doc__=
 #include <ctype.h>
 #include <unistd.h>
 #include <locale.h>
+#include <stdint.h>
 
 #include <getopt.h>
 #include <net/if.h>


### PR DESCRIPTION
Fixes the following error

	napi_monitor_user.c:61:1: error: unknown type name ‘uint64_t’; did you mean ‘u_int64_t’?
	 uint64_t gettime(void)
	 ^~~~~~~~
	 u_int64_t
	napi_monitor_user.c: In function ‘gettime’:
	napi_monitor_user.c:71:10: error: ‘uint64_t’ undeclared (first use in this function); did you mean ‘u_int64_t’?
	  return (uint64_t) t.tv_sec * NANOSEC_PER_SEC + t.tv_nsec;
	          ^~~~~~~~
	          u_int64_t
	napi_monitor_user.c:71:10: note: each undeclared identifier is reported only once for each function it appears in
	napi_monitor_user.c:71:20: error: expected ‘;’ before ‘t’
	  return (uint64_t) t.tv_sec * NANOSEC_PER_SEC + t.tv_nsec;
	                    ^
	napi_monitor_user.c:72:1: warning: control reaches end of non-void function [-Wreturn-type]
	 }
	 ^
	make: *** [Makefile:184: napi_monitor] Error 1

$ gcc -v
  <snip>
  gcc version 7.1.1 20170622 (Red Hat 7.1.1-3) (GCC)

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>