### PR TITLE
Hints: Add basic benchmark module for traits proposal

### DIFF
--- a/kernel/config.default
+++ b/kernel/config.default
@@ -35,3 +35,6 @@ CONFIG_PAGE_BULK_API=n
 
 # New benchmarking modules for testing page_pool
 CONFIG_BENCH_PAGE_POOL=m
+
+# Features under development
+# CONFIG_BENCH_TRAITS=m

--- a/kernel/lib/Kbuild
+++ b/kernel/lib/Kbuild
@@ -31,3 +31,5 @@ obj-$(CONFIG_SKB_ARRAY_TESTS) += skb_array_parallel01.o
 
 obj-$(CONFIG_BENCH_PAGE_POOL) += bench_page_pool_simple.o
 obj-$(CONFIG_BENCH_PAGE_POOL) += bench_page_pool_cross_cpu.o
+
+obj-$(CONFIG_BENCH_TRAITS) += bench_traits_simple.o

--- a/kernel/lib/bench_traits_simple.c
+++ b/kernel/lib/bench_traits_simple.c
@@ -54,26 +54,6 @@ static int time_bench_for_loop(
 	return loops_cnt;
 }
 
-static int time_bench_atomic_inc(
-	struct time_bench_record *rec, void *data)
-{
-	uint64_t loops_cnt = 0;
-	atomic_t cnt;
-	int i;
-
-	atomic_set(&cnt, 0);
-
-	time_bench_start(rec);
-	/** Loop to measure **/
-	for (i = 0; i < rec->loops; i++) {
-		atomic_inc(&cnt);
-		barrier(); /* avoid compiler to optimize this loop */
-	}
-	loops_cnt = atomic_read(&cnt);
-	time_bench_stop(rec, loops_cnt);
-	return loops_cnt;
-}
-
 static void noinline measured_function(volatile int *var)
 {
 	(*var) = 1;
@@ -209,8 +189,6 @@ static int run_benchmark_tests(void)
 	if (enabled(bit_run_bench_baseline)) {
 		time_bench_loop(nr_loops*10, 0,
 				"for_loop", NULL, time_bench_for_loop);
-		time_bench_loop(nr_loops*10, 0,
-				"atomic_inc", NULL, time_bench_atomic_inc);
 
 		/*  cost for a local function call */
 		time_bench_loop(loops, 0, "function_call_cost",

--- a/kernel/lib/bench_traits_simple.c
+++ b/kernel/lib/bench_traits_simple.c
@@ -25,6 +25,8 @@ MODULE_PARM_DESC(run_flags, "Limit which bench test that runs");
 /* Count the bit number from the enum */
 enum benchmark_bit {
 	bit_run_bench_baseline,
+	bit_run_bench_func,
+	bit_run_bench_func_ptr,
 	bit_run_bench_trait_set,
 	bit_run_bench_trait_get,
 };
@@ -190,18 +192,21 @@ static int run_benchmark_tests(void)
 	uint32_t nr_loops = loops;
 
 	/* Baseline tests */
-	if (enabled(bit_run_bench_baseline)) {
+	if (enabled(bit_run_bench_baseline))
 		time_bench_loop(nr_loops*10, 0,
 				"for_loop", NULL, time_bench_for_loop);
 
-		/*  cost for a local function call */
+	/* cost for a local function call */
+	if (enabled(bit_run_bench_func))
 		time_bench_loop(loops, 0, "function_call_cost",
 				NULL, time_func);
 
-		/*  cost for a function pointer invocation */
+	/* cost for a function pointer invocation (indirect call)
+	 *  - likely side-channel mitigation overhead
+	 */
+	if (enabled(bit_run_bench_func_ptr))
 		time_bench_loop(loops, 0, "func_ptr_call_cost",
 				NULL, time_func_ptr);
-	}
 
 	if (enabled(bit_run_bench_trait_set)) {
 		time_bench_loop(loops, 0, "trait_set",

--- a/kernel/lib/bench_traits_simple.c
+++ b/kernel/lib/bench_traits_simple.c
@@ -36,6 +36,10 @@ static unsigned long loops = 10000000;
 module_param(loops, ulong, 0);
 MODULE_PARM_DESC(loops, "Specify loops bench will run");
 
+static unsigned long stay_loaded = 0;
+module_param(stay_loaded, ulong, 0);
+MODULE_PARM_DESC(stay_loaded, "For perf report keep module loaded");
+
 /* Timing at the nanosec level, we need to know the overhead
  * introduced by the for loop itself */
 static int time_bench_for_loop(
@@ -225,8 +229,10 @@ static int __init bench_traits_simple_module_init(void)
 
 	run_benchmark_tests();
 
-	// return 0;
-	return -EAGAIN; // Trick to not fully load module
+	if (stay_loaded)
+		return 0;
+	else
+		return -EAGAIN; // Trick to not fully load module
 }
 module_init(bench_traits_simple_module_init);
 

--- a/kernel/lib/bench_traits_simple.c
+++ b/kernel/lib/bench_traits_simple.c
@@ -1,0 +1,113 @@
+/*
+ * Benchmark module for traits - related to XDP-hints
+ */
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
+#include <linux/module.h>
+#include <linux/time_bench.h>
+//#include <net/trait.h>
+
+static int verbose=1;
+
+/* Makes tests selectable. Useful for perf-record to analyze a single test.
+ * Hint: Bash shells support writing binary number like: $((2#101010)
+ *
+ * # modprobe bench_page_pool_simple run_flags=$((2#100))
+ */
+static unsigned long run_flags = 0xFFFFFFFF;
+module_param(run_flags, ulong, 0);
+MODULE_PARM_DESC(run_flags, "Limit which bench test that runs");
+/* Count the bit number from the enum */
+enum benchmark_bit {
+	bit_run_bench_baseline,
+};
+#define bit(b)		(1 << (b))
+#define enabled(b)	((run_flags & (bit(b))))
+
+/* notice time_bench is limited to U32_MAX nr loops */
+static unsigned long loops = 10000000;
+module_param(loops, ulong, 0);
+MODULE_PARM_DESC(loops, "Specify loops bench will run");
+
+/* Timing at the nanosec level, we need to know the overhead
+ * introduced by the for loop itself */
+static int time_bench_for_loop(
+	struct time_bench_record *rec, void *data)
+{
+	uint64_t loops_cnt = 0;
+	int i;
+
+	time_bench_start(rec);
+	/** Loop to measure **/
+	for (i = 0; i < rec->loops; i++) {
+		loops_cnt++;
+		barrier(); /* avoid compiler to optimize this loop */
+	}
+	time_bench_stop(rec, loops_cnt);
+	return loops_cnt;
+}
+
+
+static int time_bench_atomic_inc(
+	struct time_bench_record *rec, void *data)
+{
+	uint64_t loops_cnt = 0;
+	atomic_t cnt;
+	int i;
+
+	atomic_set(&cnt, 0);
+
+	time_bench_start(rec);
+	/** Loop to measure **/
+	for (i = 0; i < rec->loops; i++) {
+		atomic_inc(&cnt);
+		barrier(); /* avoid compiler to optimize this loop */
+	}
+	loops_cnt = atomic_read(&cnt);
+	time_bench_stop(rec, loops_cnt);
+	return loops_cnt;
+}
+
+static int run_benchmark_tests(void)
+{
+	uint32_t nr_loops = loops;
+
+	/* Baseline tests */
+	if (enabled(bit_run_bench_baseline)) {
+		time_bench_loop(nr_loops*10, 0,
+				"for_loop", NULL, time_bench_for_loop);
+		time_bench_loop(nr_loops*10, 0,
+				"atomic_inc", NULL, time_bench_atomic_inc);
+	}
+
+	return 0;
+}
+
+static int __init bench_traits_simple_module_init(void)
+{
+	if (verbose)
+		pr_info("Loaded\n");
+
+	if (loops > U32_MAX) {
+		pr_err("Module param loops(%lu) exceeded U32_MAX(%u)\n",
+		       loops, U32_MAX);
+		return -ECHRNG;
+	}
+
+	run_benchmark_tests();
+
+	// return 0;
+	return -EAGAIN; // Trick to not fully load module
+}
+module_init(bench_traits_simple_module_init);
+
+static void __exit bench_traits_simple_module_exit(void)
+{
+	if (verbose)
+		pr_info("Unloaded\n");
+}
+module_exit(bench_traits_simple_module_exit);
+
+MODULE_DESCRIPTION("Benchmark of traits");
+MODULE_AUTHOR("Jesper Dangaard Brouer <hawk@kernel.org>");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
This benchmark module depend on a kernel feature (currently) called "traits"

Tested on top of kernel tree and branch:

- https://github.com/arthurfabre/linux/tree/afabre/traits-002-bounds-inline

I had to export the following functions via `EXPORT_SYMBOL_GPL()` to make it compile:
- bpf_xdp_trait_set
- bpf_xdp_trait_get
- bpf_xdp_trait_del

Initial result show that overhead is too large to be acceptable for XDP.
  - More optimizations for traits are needed

This bench kernel module can be used for guiding our optimizations.

Cc. @tohojo , @arthurfabre , @LorenzoBianconi
